### PR TITLE
Added List() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go-ipset #
 
 This library is a simple GoLang wrapper to the IPtables ipset userspace utility.
-It provides an interface to allow Go programs to easily manipulate ipsets. 
+It provides an interface to allow Go programs to easily manipulate ipsets.
 It is currently limited to sets of `type hash`.
 
 For ipset command documentation: http://ipset.netfilter.org/ipset.man.html
@@ -21,7 +21,7 @@ Install dependencies:
 
 ## API Reference ##
 
-[![GoDoc](https://godoc.org/github.com/google/go-github/github?status.svg)](https://godoc.org/github.com/janeczku/go-ipset/ipset) 
+[![GoDoc](https://godoc.org/github.com/google/go-github/github?status.svg)](https://godoc.org/github.com/janeczku/go-ipset/ipset)
 
 ## Usage ##
 
@@ -81,4 +81,10 @@ For example, to create a set whose entries will expire after 60 seconds, lets sa
 
 ```go
 abusers := ipset.New("ratelimited", "hash:ip", &ipset.Params{Timeout: 60})
+```
+
+#### List entries of a set
+```go
+// list is []string
+list ipset.List("customers")
 ```

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -77,7 +77,7 @@ func initCheck() error {
 }
 
 func (s *IPSet) createHashSet(name string) error {
-/*	out, err := exec.Command("/usr/bin/sudo",
+	/*	out, err := exec.Command("/usr/bin/sudo",
 		ipsetPath, "create", name, s.HashType, "family", s.HashFamily, "hashsize", strconv.Itoa(s.HashSize),
 		"maxelem", strconv.Itoa(s.MaxElem), "timeout", strconv.Itoa(s.Timeout), "-exist").CombinedOutput()*/
 	out, err := exec.Command(ipsetPath, "create", name, s.HashType, "family", s.HashFamily, "hashsize", strconv.Itoa(s.HashSize),
@@ -203,6 +203,17 @@ func (s *IPSet) Destroy() error {
 		return fmt.Errorf("error destroying set %s: %v (%s)", s.Name, err, out)
 	}
 	return nil
+}
+
+// List is used to show the contents of a set
+func (s *IPSet) List() ([]string, error) {
+	out, err := exec.Command(ipsetPath, "list", s.Name).CombinedOutput()
+	if err != nil {
+		return []string{}, fmt.Errorf("error listing set %s: %v (%s)", s.Name, err, out)
+	}
+	r := regexp.MustCompile("(?m)^(.*\n)*Members:\n")
+	list := r.ReplaceAllString(string(out[:]), "")
+	return strings.Split(list, "\n"), nil
 }
 
 // Swap is used to hot swap two sets on-the-fly. Use with names of existing sets of the same type.


### PR DESCRIPTION
This PR adds a function to list the contents of an IPSet.
* Added README.md entry for ipset.List()
* Uses Regexp to replace everything before the output of the member list (This is used
to get the members list).

I was thinking if it would make more sense to move the List() function out of the IPSet "struct", for now I have added it to the IPSet struct.

***

If there is anything I can improve or change, please let me know.