### PR TITLE
NEW: Support for DestroyAll and Add with Option

### DIFF
--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// ipset is a library providing a wrapper to the IPtables ipset userspace utility
+// Package ipset is a library providing a wrapper to the IPtables ipset userspace utility
 package ipset
 
 import (
@@ -69,9 +69,8 @@ func initCheck() error {
 		}
 		if supportedVersion {
 			return nil
-		} else {
-			return errIpsetNotSupported
 		}
+		return errIpsetNotSupported
 	}
 	return nil
 }
@@ -215,6 +214,15 @@ func (s *IPSet) Destroy() error {
 	return nil
 }
 
+// DestroyAll is used to destroy the set.
+func (s *IPSet) DestroyAll() error {
+	out, err := exec.Command(ipsetPath, "destroy").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error destroying set %s (%s)", err, out)
+	}
+	return nil
+}
+
 // Swap is used to hot swap two sets on-the-fly. Use with names of existing sets of the same type.
 func Swap(from, to string) error {
 	out, err := exec.Command(ipsetPath, "swap", from, to).Output()
@@ -228,6 +236,14 @@ func destroyIPSet(name string) error {
 	out, err := exec.Command(ipsetPath, "destroy", name).Output()
 	if err != nil {
 		return fmt.Errorf("error destroying ipset %s: %v (%s)", name, err, out)
+	}
+	return nil
+}
+
+func destroyAll() error {
+	out, err := exec.Command(ipsetPath, "destroy").Output()
+	if err != nil {
+		return fmt.Errorf("error destroying all ipsetz %s (%s)", err, out)
 	}
 	return nil
 }

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -77,7 +77,7 @@ func initCheck() error {
 }
 
 func (s *IPSet) createHashSet(name string) error {
-/*	out, err := exec.Command("/usr/bin/sudo",
+	/*	out, err := exec.Command("/usr/bin/sudo",
 		ipsetPath, "create", name, s.HashType, "family", s.HashFamily, "hashsize", strconv.Itoa(s.HashSize),
 		"maxelem", strconv.Itoa(s.MaxElem), "timeout", strconv.Itoa(s.Timeout), "-exist").CombinedOutput()*/
 	out, err := exec.Command(ipsetPath, "create", name, s.HashType, "family", s.HashFamily, "hashsize", strconv.Itoa(s.HashSize),
@@ -174,6 +174,16 @@ func (s *IPSet) Add(entry string, timeout int) error {
 	out, err := exec.Command(ipsetPath, "add", s.Name, entry, "timeout", strconv.Itoa(timeout), "-exist").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("error adding entry %s: %v (%s)", entry, err, out)
+	}
+	return nil
+}
+
+// AddOption is used to add the specified entry to the set.
+// A timeout of 0 means that the entry will be stored permanently in the set.
+func (s *IPSet) AddOption(entry string, option string, timeout int) error {
+	out, err := exec.Command(ipsetPath, "add", s.Name, entry, option, "timeout", strconv.Itoa(timeout), "-exist").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error adding entry %s with option %s : %v (%s)", entry, option, err, out)
 	}
 	return nil
 }

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -215,7 +215,8 @@ func (s *IPSet) Destroy() error {
 }
 
 // DestroyAll is used to destroy the set.
-func (s *IPSet) DestroyAll() error {
+func DestroyAll() error {
+	initCheck()
 	out, err := exec.Command(ipsetPath, "destroy").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("error destroying set %s (%s)", err, out)


### PR DESCRIPTION
Adding support for options.
Adding support for DestroyAll.
This will for example support the "Nomatch" option that allows to remote part of a subnet for matching.