### PR TITLE
Wrong casing

### DIFF
--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/coreos/go-semver/semver"
 )
 


### PR DESCRIPTION
go get github.com/janeczku/go-ipset/ipset
go: github.com/janeczku/go-ipset/ipset imports
	github.com/Sirupsen/logrus: github.com/Sirupsen/logrus@v1.5.0: parsing go.mod:
	module declares its path as: github.com/sirupsen/logrus
	        but was required as: github.com/Sirupsen/logrus